### PR TITLE
add SBT balanced invariant

### DIFF
--- a/test/T3T4/T3andT4Spec.hs
+++ b/test/T3T4/T3andT4Spec.hs
@@ -68,11 +68,25 @@ propertyTFromList = testProperty "tree tFromList" prop_tFromList
 
 -- ADVANCED --
 
+tlsize :: Tree a -> Int
+tlsize Leaf             = 0
+tlsize (Branch _ l _ _) = tsize l
+
+trsize :: Tree a -> Int
+trsize Leaf             = 0
+trsize (Branch _ _ _ r) = tsize r
+
+
 isBalanced :: Tree a -> Bool
 isBalanced Leaf = True
 isBalanced (Branch _ l _ r)
-    | abs (tdepth l - tdepth r) <= 1 = isBalanced l && isBalanced r
+    | abs (tdepth l - tdepth r) <= 1 = bothBalanced
+    | tsize l >= tlsize r && tsize l >= trsize r
+        && tsize r >= tlsize l && tsize r >= trsize l
+        = bothBalanced
     | otherwise                      = False
+    where
+        bothBalanced = isBalanced l && isBalanced r
 
 prop_balanced :: Property
 prop_balanced = property $ do

--- a/test/T3T4/T3andT4Spec.hs
+++ b/test/T3T4/T3andT4Spec.hs
@@ -77,22 +77,25 @@ trsize Leaf             = 0
 trsize (Branch _ _ _ r) = tsize r
 
 
-isBalanced :: Tree a -> Bool
-isBalanced Leaf = True
-isBalanced (Branch _ l _ r)
-    | abs (tdepth l - tdepth r) <= 1 = bothBalanced
-    | tsize l >= tlsize r && tsize l >= trsize r
-        && tsize r >= tlsize l && tsize r >= trsize l
-        = bothBalanced
+isBalancedDepth :: Tree a -> Bool
+isBalancedDepth Leaf = True
+isBalancedDepth (Branch _ l _ r)
+    | abs (tdepth l - tdepth r) <= 1 = isBalancedDepth l && isBalancedDepth r
     | otherwise                      = False
-    where
-        bothBalanced = isBalanced l && isBalanced r
+
+isBalancedSize :: Tree a -> Bool
+isBalancedSize Leaf = True
+isBalancedSize (Branch _ l _ r)
+    | tsize l >= tlsize r && tsize l >= trsize r &&
+      tsize r >= tlsize l && tsize r >= trsize l
+                = isBalancedSize l && isBalancedSize r
+    | otherwise = False
 
 prop_balanced :: Property
 prop_balanced = property $ do
     xs <- forAll genList
     let tree = tFromList xs
-    assert $ isBalanced tree
+    assert $ isBalancedDepth tree || isBalancedSize tree
 
 propertyBalanced :: TestTree
 propertyBalanced = testProperty "tree balanced" prop_balanced


### PR DESCRIPTION
Было бы логично реализовывать дерево только с весом при помощи [size-balanced-tree](http://wcipeg.com/wiki/Size_Balanced_Tree), но его инвариант не поддерживался тестами.
Раздвоена проверка баланса: `isBalancedDepth` и `isBalancedSize`

возвращена директория `src` (при помощи `.gitkeep`)